### PR TITLE
Makes all interpret functions monomorphic

### DIFF
--- a/examples/docs/SSR.purs
+++ b/examples/docs/SSR.purs
@@ -9,7 +9,7 @@ import Deku.DOM as D
 import Deku.Listeners (click_, slider)
 import Deku.Pursx (nut, (~~))
 import Deku.Toplevel (Template(..), runSSR)
-import FRP.Event (bang, fold, makeEvent)
+import FRP.Event (bang, fold, fromEvent, makeEvent)
 import FRP.Event.VBus (V)
 import Type.Proxy (Proxy(..))
 
@@ -224,7 +224,7 @@ and all of the dynamic bits are hydrated on page load.""" <> "\"\"\"" <> """
       ( D.pre_
           [ D.code_
               [ text
-                  ( makeEvent \k ->
+                  (fromEvent( makeEvent \k ->
                       ( ( runSSR
                             ( Template
                                 { head:
@@ -235,7 +235,7 @@ and all of the dynamic bits are hydrated on page load.""" <> "\"\"\"" <> """
                             app
                         ) >>= k
                       ) *> (pure (pure unit))
-                  )
+                  ))
               ]
           ]
       )

--- a/spago.dhall
+++ b/spago.dhall
@@ -6,7 +6,6 @@
   , "control"
   , "debug"
   , "effect"
-  , "either"
   , "exceptions"
   , "fast-vect"
   , "filterable"


### PR DESCRIPTION
In order to get magic `do` optimizations, we make all interpret functions monomorphic. The consumer of these functions still needs to make their deku tree polymorphic (via `Korok`) as the interpreter is unknown at that point, but once the deku tree hits the interpreter, the interpreter will be monomorphic.