### PR TITLE
Use mermaid for SSR and Hydration

### DIFF
--- a/codegen.py
+++ b/codegen.py
@@ -108,10 +108,11 @@ def cg(CODEGEN_TARGET, ival = None, ival2 = None):
             typ = 'T'+term
             print_(f'''module Deku.DOM.Elt.{term.split('_')[0]} where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -119,7 +120,7 @@ data {term}
 
 {x}
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute {term})
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -127,7 +128,7 @@ data {term}
 
 {x}_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 {x}_ = {x} empty

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"filter-console": "^0.1.1",
 		"headless-devtools": "^2.0.1",
 		"netlify-cli": "^8.0.1",
+		"parcel": "^2.7.0",
 		"psc-package": "^4.0.1",
 		"pulp": "^15.0.0",
 		"puppeteer": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 		"filter-console": "^0.1.1",
 		"headless-devtools": "^2.0.1",
 		"netlify-cli": "^8.0.1",
-		"parcel": "^2.7.0",
 		"psc-package": "^4.0.1",
 		"pulp": "^15.0.0",
 		"puppeteer": "^5.2.0",

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,117 +1,25 @@
-{-
-Welcome to your new Dhall package-set!
-
-Below are instructions for how to edit this file for most use
-cases, so that you don't need to know Dhall to use it.
-
-## Warning: Don't Move This Top-Level Comment!
-
-Due to how `dhall format` currently works, this comment's
-instructions cannot appear near corresponding sections below
-because `dhall format` will delete the comment. However,
-it will not delete a top-level comment like this one.
-
-## Use Cases
-
-Most will want to do one or both of these options:
-1. Override/Patch a package's dependency
-2. Add a package not already in the default package set
-
-This file will continue to work whether you use one or both options.
-Instructions for each option are explained below.
-
-### Overriding/Patching a package
-
-Purpose:
-- Change a package's dependency to a newer/older release than the
-    default package set's release
-- Use your own modified version of some dependency that may
-    include new API, changed API, removed API by
-    using your custom git repo of the library rather than
-    the package set's repo
-
-Syntax:
-where `entityName` is one of the following:
-- dependencies
-- repo
-- version
--------------------------------
-let upstream = --
-in  upstream
-  with packageName.entityName = "new value"
--------------------------------
-
-Example:
--------------------------------
-let upstream = --
-in  upstream
-  with halogen.version = "master"
-  with halogen.repo = "https://example.com/path/to/git/repo.git"
-
-  with halogen-vdom.version = "v4.0.0"
--------------------------------
-
-### Additions
-
-Purpose:
-- Add packages that aren't already included in the default package set
-
-Syntax:
-where `<version>` is:
-- a tag (i.e. "v4.0.0")
-- a branch (i.e. "master")
-- commit hash (i.e. "701f3e44aafb1a6459281714858fadf2c4c2a977")
--------------------------------
-let upstream = --
-in  upstream
-  with new-package-name =
-    { dependencies =
-       [ "dependency1"
-       , "dependency2"
-       ]
-    , repo =
-       "https://example.com/path/to/git/repo.git"
-    , version =
-        "<version>"
-    }
--------------------------------
-
-Example:
--------------------------------
-let upstream = --
-in  upstream
-  with benchotron =
-      { dependencies =
-          [ "arrays"
-          , "exists"
-          , "profunctor"
-          , "strings"
-          , "quickcheck"
-          , "lcg"
-          , "transformers"
-          , "foldable-traversable"
-          , "exceptions"
-          , "node-fs"
-          , "node-buffer"
-          , "node-readline"
-          , "datetime"
-          , "now"
-          ]
-      , repo =
-          "https://github.com/hdgarrood/purescript-benchotron.git"
-      , version =
-          "v7.0.0"
-      }
--------------------------------
--}
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.2-20220624/packages.dhall
-        sha256:08989ed9f53e381f879f1b7012ad7684b1ed64d7164c4ad75e306d3210a46c92
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.4-20220805/packages.dhall
+        sha256:c80e241af3ba62fc42284b9bc26b4c9bd4525eebe4ab0e9198c9bbeac102f656
 
 let overrides =
       { bolson =
         { dependencies = [ "prelude" ]
         , repo = "https://github.com/mikesol/purescript-bolson.git"
+        , version = "main"
+        }
+      , mermaid =
+        { dependencies =
+          [ "effect"
+          , "free"
+          , "maybe"
+          , "mmorph"
+          , "prelude"
+          , "st"
+          , "tailrec"
+          , "transformers"
+          ]
+        , repo = "https://github.com/purefunctor/purescript-mermaid.git"
         , version = "main"
         }
       }

--- a/pursx.py
+++ b/pursx.py
@@ -10,6 +10,7 @@ import Prelude
 import Bolson.Control as Bolson
 import Bolson.Core (Element(..), Entity(..), PSR)
 import Control.Alt ((<|>))
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (unwrap)
@@ -17,7 +18,7 @@ import Data.Profunctor (lcmap)
 import Data.Reflectable (class Reflectable, reflectType)
 import Data.Symbol (class IsSymbol)
 import Deku.Attribute (Attribute, AttributeValue(..), unsafeUnAttribute)
-import Deku.Core (DOMInterpret(..), class Korok, Domable, Node(..))
+import Deku.Core (DOMInterpret(..), Domable, Node(..))
 import Deku.DOM (class TagToDeku)
 import FRP.Event (AnEvent, bang, subscribe, makeEvent)
 import Foreign.Object as Object
@@ -162,7 +163,7 @@ instance pursxToElementConsInsert ::
   , PursxToElement m lock payload rest r
   , Reflectable key String
   , IsSymbol key
-  , Korok s m
+  , MonadST s m
   ) =>
   PursxToElement m
     lock
@@ -193,7 +194,7 @@ else instance pursxToElementConsAttr ::
   , PursxToElement m lock payload rest r
   , Reflectable key String
   , IsSymbol key
-  , Korok s m
+  , MonadST s m
   ) =>
   PursxToElement m
     lock
@@ -236,7 +237,7 @@ psx
   :: forall s m lock payload (html :: Symbol)
    . Reflectable html String
   => PXStart m lock payload "~" " " html ()
-  => Korok s m
+  => MonadST s m
   => PursxToElement m lock payload RL.Nil ()
   => Proxy html
   -> Domable m lock payload
@@ -248,7 +249,7 @@ makePursx
   => PXStart m lock payload "~" " " html r
   => RL.RowToList r rl
   => PursxToElement m lock payload rl r
-  => Korok s m
+  => MonadST s m
   => Proxy html
   -> { | r }
   -> Domable m lock payload
@@ -260,7 +261,7 @@ makePursx'
   => Reflectable verb String
   => PXStart m lock payload verb " " html r
   => RL.RowToList r rl
-  => Korok s m
+  => MonadST s m
   => PursxToElement m lock payload rl r
   => Proxy verb
   -> Proxy html
@@ -298,7 +299,7 @@ makePursx' verb html r = Element' $ Node go
 
 __internalDekuFlatten
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => PSR m
   -> DOMInterpret m payload
   -> Domable m lock payload

--- a/spago.dhall
+++ b/spago.dhall
@@ -11,6 +11,7 @@
   , "heterogeneous"
   , "hyrule"
   , "maybe"
+  , "mermaid"
   , "monoid-extras"
   , "newtype"
   , "ordered-collections"

--- a/spago.dhall
+++ b/spago.dhall
@@ -34,5 +34,5 @@
 , license = "Apache-2.0"
 , packages = ./packages.dhall
 , repository = "https://github.com/mikesol/purescript-deku"
-, sources = [ "src/**/*.purs", "live/**/*.purs" ]
+, sources = [ "src/**/*.purs" ]
 }

--- a/spago.dhall
+++ b/spago.dhall
@@ -2,6 +2,7 @@
 , dependencies =
   [ "arrays"
   , "bolson"
+  , "console"
   , "control"
   , "effect"
   , "fast-vect"
@@ -33,5 +34,5 @@
 , license = "Apache-2.0"
 , packages = ./packages.dhall
 , repository = "https://github.com/mikesol/purescript-deku"
-, sources = [ "src/**/*.purs" ]
+, sources = [ "src/**/*.purs", "live/**/*.purs" ]
 }

--- a/src/Deku/Control.purs
+++ b/src/Deku/Control.purs
@@ -16,6 +16,7 @@ import Bolson.Control (switcher)
 import Bolson.Control as Bolson
 import Bolson.Core (Element(..), Entity(..), EventfulElement(..), FixedChildren(..), PSR, Scope(..))
 import Control.Alt ((<|>))
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Data.FastVect.FastVect (Vect)
 import Data.Foldable (oneOf)
@@ -23,7 +24,7 @@ import Data.Maybe (Maybe(..), maybe)
 import Data.Newtype (class Newtype, unwrap)
 import Data.Profunctor (lcmap)
 import Deku.Attribute (Attribute, AttributeValue(..), unsafeUnAttribute)
-import Deku.Core (class Korok, DOMInterpret(..), Domable, Node(..))
+import Deku.Core (DOMInterpret(..), Domable, Node(..))
 import FRP.Event (AnEvent, bang, makeEvent, subscribe)
 import Prim.Int (class Compare)
 import Prim.Ordering (GT)
@@ -82,7 +83,7 @@ unsafeSetAttribute (DOMInterpret { setProp, setCb }) id atts = map
 
 elementify
   :: forall s m element lock payload
-   . Korok s m
+   . MonadST s m
   => String
   -> AnEvent m (Attribute element)
   -> Domable m lock payload
@@ -117,7 +118,7 @@ elementify tag atts children = Node go
 globalPortal
   :: forall n s m lock payload
    . Compare n Neg1 GT
-  => Korok s m
+  => MonadST s m
   => Vect n (Domable m lock payload)
   -> (Vect n (Domable m lock payload) -> Domable m lock payload)
   -> Domable m lock payload
@@ -166,7 +167,7 @@ portalFlatten =
 portal
   :: forall n s m lock0 payload
    . Compare n Neg1 GT
-  => Korok s m
+  => MonadST s m
   => Vect n (Domable m lock0 payload)
   -> ( forall lockfoo
         . Vect n (Domable m lockfoo payload)
@@ -210,7 +211,7 @@ text_ txt = text (bang txt)
 
 deku
   :: forall s m payload
-   . Korok s m
+   . MonadST s m
   => Web.DOM.Element
   -> (forall lock. Domable m lock payload)
   -> DOMInterpret m payload
@@ -231,7 +232,7 @@ deku root children di@(DOMInterpret { ids, makeRoot }) = makeEvent \k -> do
 
 deku1
   :: forall s m payload
-   . Korok s m
+   . MonadST s m
   => Web.DOM.Element
   -> (forall lock. AnEvent m (Domable m lock payload))
   -> DOMInterpret m payload
@@ -240,7 +241,7 @@ deku1 root children = deku root (EventfulElement' $ EventfulElement children)
 
 dekuA
   :: forall s m payload
-   . Korok s m
+   . MonadST s m
   => Web.DOM.Element
   -> (forall lock. Array (Domable m lock payload))
   -> DOMInterpret m payload
@@ -251,7 +252,7 @@ data Stage = Begin | Middle | End
 
 __internalDekuFlatten
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => PSR m
   -> DOMInterpret m payload
   -> Domable m lock payload

--- a/src/Deku/Core.purs
+++ b/src/Deku/Core.purs
@@ -34,12 +34,9 @@ import Prelude
 import Bolson.Always (AlwaysEffect, halways)
 import Bolson.Core (Scope, fixed, dyn, envy)
 import Bolson.Core as Bolson
-import Control.Monad.ST (ST)
 import Control.Monad.ST.Class (class MonadST)
-import Control.Monad.ST.Global (Global)
 import Data.Maybe (Maybe)
 import Data.Monoid.Always (class Always, always)
-import Data.Monoid.Endo (Endo)
 import Data.Newtype (class Newtype)
 import Data.Profunctor (lcmap)
 import Data.Tuple (curry)
@@ -51,7 +48,6 @@ import FRP.Event as FRP.Event
 import FRP.Event.VBus (class VBus, V, vbus)
 import Foreign.Object (Object)
 import Heterogeneous.Mapping (class MapRecordWithIndex, ConstMapping)
-import Mermaid (Mermaid)
 import Prim.RowList (class RowToList)
 import Type.Proxy (Proxy(..))
 import Web.DOM as Web.DOM

--- a/src/Deku/DOM.purs
+++ b/src/Deku/DOM.purs
@@ -348,7 +348,7 @@ module Deku.DOM
   -- codegen 0
   ) where
 
-import Deku.Attribute
+import Deku.Attribute (class Attr, unsafeAttribute, cb', Cb(..))
 
 -- codegen 9
 import Deku.DOM.Attr.Accept (Accept(..))

--- a/src/Deku/DOM/Attr/Color.purs
+++ b/src/Deku/DOM/Attr/Color.purs
@@ -1,14 +1,10 @@
 module Deku.DOM.Attr.Color where
 
-import Deku.DOM.Elt.Basefont (Basefont_)
 import Deku.DOM.Elt.Font (Font_)
 import Deku.DOM.Elt.Hr (Hr_)
 import Deku.Attribute (class Attr, prop', unsafeAttribute)
 
 data Color = Color
-
-instance Attr Basefont_ Color String where
-  attr Color value = unsafeAttribute { key: "color", value: prop' value }
 
 instance Attr Font_ Color String where
   attr Color value = unsafeAttribute { key: "color", value: prop' value }

--- a/src/Deku/DOM/Elt/A.purs
+++ b/src/Deku/DOM/Elt/A.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.A where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data A_
 
 a
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute A_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ a attributes kids = Element' (elementify "a" attributes (fixed kids))
 
 a_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 a_ = a empty

--- a/src/Deku/DOM/Elt/Abbr.purs
+++ b/src/Deku/DOM/Elt/Abbr.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Abbr where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Abbr_
 
 abbr
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Abbr_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ abbr attributes kids = Element' (elementify "abbr" attributes (fixed kids))
 
 abbr_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 abbr_ = abbr empty

--- a/src/Deku/DOM/Elt/Acronym.purs
+++ b/src/Deku/DOM/Elt/Acronym.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Acronym where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Acronym_
 
 acronym
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Acronym_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ acronym attributes kids = Element'
 
 acronym_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 acronym_ = acronym empty

--- a/src/Deku/DOM/Elt/Address.purs
+++ b/src/Deku/DOM/Elt/Address.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Address where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Address_
 
 address
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Address_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ address attributes kids = Element'
 
 address_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 address_ = address empty

--- a/src/Deku/DOM/Elt/Applet.purs
+++ b/src/Deku/DOM/Elt/Applet.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Applet where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Applet_
 
 applet
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Applet_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ applet attributes kids = Element' (elementify "applet" attributes (fixed kids))
 
 applet_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 applet_ = applet empty

--- a/src/Deku/DOM/Elt/Area.purs
+++ b/src/Deku/DOM/Elt/Area.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Area where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Area_
 
 area
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Area_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ area attributes kids = Element' (elementify "area" attributes (fixed kids))
 
 area_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 area_ = area empty

--- a/src/Deku/DOM/Elt/Article.purs
+++ b/src/Deku/DOM/Elt/Article.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Article where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Article_
 
 article
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Article_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ article attributes kids = Element'
 
 article_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 article_ = article empty

--- a/src/Deku/DOM/Elt/Aside.purs
+++ b/src/Deku/DOM/Elt/Aside.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Aside where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Aside_
 
 aside
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Aside_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ aside attributes kids = Element' (elementify "aside" attributes (fixed kids))
 
 aside_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 aside_ = aside empty

--- a/src/Deku/DOM/Elt/Audio.purs
+++ b/src/Deku/DOM/Elt/Audio.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Audio where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Audio_
 
 audio
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Audio_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ audio attributes kids = Element' (elementify "audio" attributes (fixed kids))
 
 audio_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 audio_ = audio empty

--- a/src/Deku/DOM/Elt/B.purs
+++ b/src/Deku/DOM/Elt/B.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.B where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data B_
 
 b
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute B_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ b attributes kids = Element' (elementify "b" attributes (fixed kids))
 
 b_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 b_ = b empty

--- a/src/Deku/DOM/Elt/Base.purs
+++ b/src/Deku/DOM/Elt/Base.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Base where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Base_
 
 base
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Base_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ base attributes kids = Element' (elementify "base" attributes (fixed kids))
 
 base_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 base_ = base empty

--- a/src/Deku/DOM/Elt/Basefont.purs
+++ b/src/Deku/DOM/Elt/Basefont.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Basefont where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Basefont_
 
 basefont
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Basefont_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ basefont attributes kids = Element'
 
 basefont_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 basefont_ = basefont empty

--- a/src/Deku/DOM/Elt/Bdi.purs
+++ b/src/Deku/DOM/Elt/Bdi.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Bdi where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Bdi_
 
 bdi
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Bdi_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ bdi attributes kids = Element' (elementify "bdi" attributes (fixed kids))
 
 bdi_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 bdi_ = bdi empty

--- a/src/Deku/DOM/Elt/Bdo.purs
+++ b/src/Deku/DOM/Elt/Bdo.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Bdo where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Bdo_
 
 bdo
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Bdo_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ bdo attributes kids = Element' (elementify "bdo" attributes (fixed kids))
 
 bdo_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 bdo_ = bdo empty

--- a/src/Deku/DOM/Elt/Big.purs
+++ b/src/Deku/DOM/Elt/Big.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Big where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Big_
 
 big
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Big_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ big attributes kids = Element' (elementify "big" attributes (fixed kids))
 
 big_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 big_ = big empty

--- a/src/Deku/DOM/Elt/Blockquote.purs
+++ b/src/Deku/DOM/Elt/Blockquote.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Blockquote where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Blockquote_
 
 blockquote
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Blockquote_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ blockquote attributes kids = Element'
 
 blockquote_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 blockquote_ = blockquote empty

--- a/src/Deku/DOM/Elt/Body.purs
+++ b/src/Deku/DOM/Elt/Body.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Body where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Body_
 
 body
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Body_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ body attributes kids = Element' (elementify "body" attributes (fixed kids))
 
 body_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 body_ = body empty

--- a/src/Deku/DOM/Elt/Br.purs
+++ b/src/Deku/DOM/Elt/Br.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Br where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Br_
 
 br
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Br_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ br attributes kids = Element' (elementify "br" attributes (fixed kids))
 
 br_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 br_ = br empty

--- a/src/Deku/DOM/Elt/Button.purs
+++ b/src/Deku/DOM/Elt/Button.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Button where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Button_
 
 button
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Button_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ button attributes kids = Element' (elementify "button" attributes (fixed kids))
 
 button_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 button_ = button empty

--- a/src/Deku/DOM/Elt/Canvas.purs
+++ b/src/Deku/DOM/Elt/Canvas.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Canvas where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Canvas_
 
 canvas
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Canvas_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ canvas attributes kids = Element' (elementify "canvas" attributes (fixed kids))
 
 canvas_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 canvas_ = canvas empty

--- a/src/Deku/DOM/Elt/Caption.purs
+++ b/src/Deku/DOM/Elt/Caption.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Caption where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Caption_
 
 caption
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Caption_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ caption attributes kids = Element'
 
 caption_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 caption_ = caption empty

--- a/src/Deku/DOM/Elt/Center.purs
+++ b/src/Deku/DOM/Elt/Center.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Center where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Center_
 
 center
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Center_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ center attributes kids = Element' (elementify "center" attributes (fixed kids))
 
 center_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 center_ = center empty

--- a/src/Deku/DOM/Elt/Cite.purs
+++ b/src/Deku/DOM/Elt/Cite.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Cite where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Cite_
 
 cite
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Cite_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ cite attributes kids = Element' (elementify "cite" attributes (fixed kids))
 
 cite_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 cite_ = cite empty

--- a/src/Deku/DOM/Elt/Code.purs
+++ b/src/Deku/DOM/Elt/Code.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Code where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Code_
 
 code
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Code_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ code attributes kids = Element' (elementify "code" attributes (fixed kids))
 
 code_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 code_ = code empty

--- a/src/Deku/DOM/Elt/Col.purs
+++ b/src/Deku/DOM/Elt/Col.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Col where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Col_
 
 col
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Col_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ col attributes kids = Element' (elementify "col" attributes (fixed kids))
 
 col_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 col_ = col empty

--- a/src/Deku/DOM/Elt/Colgroup.purs
+++ b/src/Deku/DOM/Elt/Colgroup.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Colgroup where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Colgroup_
 
 colgroup
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Colgroup_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ colgroup attributes kids = Element'
 
 colgroup_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 colgroup_ = colgroup empty

--- a/src/Deku/DOM/Elt/Datalist.purs
+++ b/src/Deku/DOM/Elt/Datalist.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Datalist where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Datalist_
 
 datalist
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Datalist_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ datalist attributes kids = Element'
 
 datalist_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 datalist_ = datalist empty

--- a/src/Deku/DOM/Elt/Dd.purs
+++ b/src/Deku/DOM/Elt/Dd.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Dd where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Dd_
 
 dd
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Dd_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ dd attributes kids = Element' (elementify "dd" attributes (fixed kids))
 
 dd_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 dd_ = dd empty

--- a/src/Deku/DOM/Elt/Del.purs
+++ b/src/Deku/DOM/Elt/Del.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Del where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Del_
 
 del
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Del_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ del attributes kids = Element' (elementify "del" attributes (fixed kids))
 
 del_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 del_ = del empty

--- a/src/Deku/DOM/Elt/Details.purs
+++ b/src/Deku/DOM/Elt/Details.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Details where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Details_
 
 details
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Details_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ details attributes kids = Element'
 
 details_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 details_ = details empty

--- a/src/Deku/DOM/Elt/Dfn.purs
+++ b/src/Deku/DOM/Elt/Dfn.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Dfn where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Dfn_
 
 dfn
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Dfn_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ dfn attributes kids = Element' (elementify "dfn" attributes (fixed kids))
 
 dfn_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 dfn_ = dfn empty

--- a/src/Deku/DOM/Elt/Dialog.purs
+++ b/src/Deku/DOM/Elt/Dialog.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Dialog where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Dialog_
 
 dialog
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Dialog_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ dialog attributes kids = Element' (elementify "dialog" attributes (fixed kids))
 
 dialog_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 dialog_ = dialog empty

--- a/src/Deku/DOM/Elt/Dir.purs
+++ b/src/Deku/DOM/Elt/Dir.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Dir where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Dir_
 
 dir
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Dir_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ dir attributes kids = Element' (elementify "dir" attributes (fixed kids))
 
 dir_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 dir_ = dir empty

--- a/src/Deku/DOM/Elt/Div.purs
+++ b/src/Deku/DOM/Elt/Div.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Div where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Div_
 
 div
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Div_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ div attributes kids = Element' (elementify "div" attributes (fixed kids))
 
 div_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 div_ = div empty

--- a/src/Deku/DOM/Elt/Dl.purs
+++ b/src/Deku/DOM/Elt/Dl.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Dl where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Dl_
 
 dl
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Dl_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ dl attributes kids = Element' (elementify "dl" attributes (fixed kids))
 
 dl_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 dl_ = dl empty

--- a/src/Deku/DOM/Elt/Dt.purs
+++ b/src/Deku/DOM/Elt/Dt.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Dt where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Dt_
 
 dt
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Dt_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ dt attributes kids = Element' (elementify "dt" attributes (fixed kids))
 
 dt_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 dt_ = dt empty

--- a/src/Deku/DOM/Elt/Em.purs
+++ b/src/Deku/DOM/Elt/Em.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Em where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Em_
 
 em
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Em_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ em attributes kids = Element' (elementify "em" attributes (fixed kids))
 
 em_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 em_ = em empty

--- a/src/Deku/DOM/Elt/Embed.purs
+++ b/src/Deku/DOM/Elt/Embed.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Embed where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Embed_
 
 embed
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Embed_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ embed attributes kids = Element' (elementify "embed" attributes (fixed kids))
 
 embed_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 embed_ = embed empty

--- a/src/Deku/DOM/Elt/Fieldset.purs
+++ b/src/Deku/DOM/Elt/Fieldset.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Fieldset where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Fieldset_
 
 fieldset
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Fieldset_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ fieldset attributes kids = Element'
 
 fieldset_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 fieldset_ = fieldset empty

--- a/src/Deku/DOM/Elt/Figcaption.purs
+++ b/src/Deku/DOM/Elt/Figcaption.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Figcaption where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Figcaption_
 
 figcaption
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Figcaption_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ figcaption attributes kids = Element'
 
 figcaption_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 figcaption_ = figcaption empty

--- a/src/Deku/DOM/Elt/Figure.purs
+++ b/src/Deku/DOM/Elt/Figure.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Figure where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Figure_
 
 figure
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Figure_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ figure attributes kids = Element' (elementify "figure" attributes (fixed kids))
 
 figure_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 figure_ = figure empty

--- a/src/Deku/DOM/Elt/Font.purs
+++ b/src/Deku/DOM/Elt/Font.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Font where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Font_
 
 font
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Font_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ font attributes kids = Element' (elementify "font" attributes (fixed kids))
 
 font_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 font_ = font empty

--- a/src/Deku/DOM/Elt/Footer.purs
+++ b/src/Deku/DOM/Elt/Footer.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Footer where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Footer_
 
 footer
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Footer_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ footer attributes kids = Element' (elementify "footer" attributes (fixed kids))
 
 footer_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 footer_ = footer empty

--- a/src/Deku/DOM/Elt/Form.purs
+++ b/src/Deku/DOM/Elt/Form.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Form where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Form_
 
 form
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Form_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ form attributes kids = Element' (elementify "form" attributes (fixed kids))
 
 form_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 form_ = form empty

--- a/src/Deku/DOM/Elt/Frame.purs
+++ b/src/Deku/DOM/Elt/Frame.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Frame where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Frame_
 
 frame
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Frame_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ frame attributes kids = Element' (elementify "frame" attributes (fixed kids))
 
 frame_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 frame_ = frame empty

--- a/src/Deku/DOM/Elt/Frameset.purs
+++ b/src/Deku/DOM/Elt/Frameset.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Frameset where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Frameset_
 
 frameset
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Frameset_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ frameset attributes kids = Element'
 
 frameset_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 frameset_ = frameset empty

--- a/src/Deku/DOM/Elt/H1.purs
+++ b/src/Deku/DOM/Elt/H1.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.H1 where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data H1_
 
 h1
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute H1_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ h1 attributes kids = Element' (elementify "h1" attributes (fixed kids))
 
 h1_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 h1_ = h1 empty

--- a/src/Deku/DOM/Elt/H2.purs
+++ b/src/Deku/DOM/Elt/H2.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.H2 where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data H2_
 
 h2
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute H2_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ h2 attributes kids = Element' (elementify "h2" attributes (fixed kids))
 
 h2_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 h2_ = h2 empty

--- a/src/Deku/DOM/Elt/H3.purs
+++ b/src/Deku/DOM/Elt/H3.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.H3 where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data H3_
 
 h3
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute H3_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ h3 attributes kids = Element' (elementify "h3" attributes (fixed kids))
 
 h3_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 h3_ = h3 empty

--- a/src/Deku/DOM/Elt/H4.purs
+++ b/src/Deku/DOM/Elt/H4.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.H4 where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data H4_
 
 h4
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute H4_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ h4 attributes kids = Element' (elementify "h4" attributes (fixed kids))
 
 h4_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 h4_ = h4 empty

--- a/src/Deku/DOM/Elt/H5.purs
+++ b/src/Deku/DOM/Elt/H5.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.H5 where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data H5_
 
 h5
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute H5_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ h5 attributes kids = Element' (elementify "h5" attributes (fixed kids))
 
 h5_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 h5_ = h5 empty

--- a/src/Deku/DOM/Elt/H6.purs
+++ b/src/Deku/DOM/Elt/H6.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.H6 where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data H6_
 
 h6
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute H6_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ h6 attributes kids = Element' (elementify "h6" attributes (fixed kids))
 
 h6_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 h6_ = h6 empty

--- a/src/Deku/DOM/Elt/Head.purs
+++ b/src/Deku/DOM/Elt/Head.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Head where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Head_
 
 head
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Head_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ head attributes kids = Element' (elementify "head" attributes (fixed kids))
 
 head_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 head_ = head empty

--- a/src/Deku/DOM/Elt/Header.purs
+++ b/src/Deku/DOM/Elt/Header.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Header where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Header_
 
 header
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Header_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ header attributes kids = Element' (elementify "header" attributes (fixed kids))
 
 header_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 header_ = header empty

--- a/src/Deku/DOM/Elt/Hr.purs
+++ b/src/Deku/DOM/Elt/Hr.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Hr where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Hr_
 
 hr
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Hr_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ hr attributes kids = Element' (elementify "hr" attributes (fixed kids))
 
 hr_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 hr_ = hr empty

--- a/src/Deku/DOM/Elt/Html.purs
+++ b/src/Deku/DOM/Elt/Html.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Html where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Html_
 
 html
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Html_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ html attributes kids = Element' (elementify "html" attributes (fixed kids))
 
 html_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 html_ = html empty

--- a/src/Deku/DOM/Elt/I.purs
+++ b/src/Deku/DOM/Elt/I.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.I where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data I_
 
 i
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute I_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ i attributes kids = Element' (elementify "i" attributes (fixed kids))
 
 i_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 i_ = i empty

--- a/src/Deku/DOM/Elt/Iframe.purs
+++ b/src/Deku/DOM/Elt/Iframe.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Iframe where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Iframe_
 
 iframe
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Iframe_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ iframe attributes kids = Element' (elementify "iframe" attributes (fixed kids))
 
 iframe_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 iframe_ = iframe empty

--- a/src/Deku/DOM/Elt/Img.purs
+++ b/src/Deku/DOM/Elt/Img.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Img where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Img_
 
 img
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Img_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ img attributes kids = Element' (elementify "img" attributes (fixed kids))
 
 img_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 img_ = img empty

--- a/src/Deku/DOM/Elt/Input.purs
+++ b/src/Deku/DOM/Elt/Input.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Input where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Input_
 
 input
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Input_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ input attributes kids = Element' (elementify "input" attributes (fixed kids))
 
 input_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 input_ = input empty

--- a/src/Deku/DOM/Elt/Ins.purs
+++ b/src/Deku/DOM/Elt/Ins.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Ins where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Ins_
 
 ins
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Ins_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ ins attributes kids = Element' (elementify "ins" attributes (fixed kids))
 
 ins_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 ins_ = ins empty

--- a/src/Deku/DOM/Elt/Kbd.purs
+++ b/src/Deku/DOM/Elt/Kbd.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Kbd where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Kbd_
 
 kbd
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Kbd_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ kbd attributes kids = Element' (elementify "kbd" attributes (fixed kids))
 
 kbd_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 kbd_ = kbd empty

--- a/src/Deku/DOM/Elt/Label.purs
+++ b/src/Deku/DOM/Elt/Label.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Label where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Label_
 
 label
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Label_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ label attributes kids = Element' (elementify "label" attributes (fixed kids))
 
 label_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 label_ = label empty

--- a/src/Deku/DOM/Elt/Legend.purs
+++ b/src/Deku/DOM/Elt/Legend.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Legend where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Legend_
 
 legend
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Legend_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ legend attributes kids = Element' (elementify "legend" attributes (fixed kids))
 
 legend_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 legend_ = legend empty

--- a/src/Deku/DOM/Elt/Li.purs
+++ b/src/Deku/DOM/Elt/Li.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Li where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Li_
 
 li
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Li_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ li attributes kids = Element' (elementify "li" attributes (fixed kids))
 
 li_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 li_ = li empty

--- a/src/Deku/DOM/Elt/Link.purs
+++ b/src/Deku/DOM/Elt/Link.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Link where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Link_
 
 link
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Link_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ link attributes kids = Element' (elementify "link" attributes (fixed kids))
 
 link_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 link_ = link empty

--- a/src/Deku/DOM/Elt/Main.purs
+++ b/src/Deku/DOM/Elt/Main.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Main where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Main_
 
 main
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Main_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ main attributes kids = Element' (elementify "main" attributes (fixed kids))
 
 main_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 main_ = main empty

--- a/src/Deku/DOM/Elt/Map.purs
+++ b/src/Deku/DOM/Elt/Map.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Map where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Map_
 
 map
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Map_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ map attributes kids = Element' (elementify "map" attributes (fixed kids))
 
 map_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 map_ = map empty

--- a/src/Deku/DOM/Elt/Mark.purs
+++ b/src/Deku/DOM/Elt/Mark.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Mark where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Mark_
 
 mark
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Mark_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ mark attributes kids = Element' (elementify "mark" attributes (fixed kids))
 
 mark_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 mark_ = mark empty

--- a/src/Deku/DOM/Elt/Meta.purs
+++ b/src/Deku/DOM/Elt/Meta.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Meta where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Meta_
 
 meta
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Meta_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ meta attributes kids = Element' (elementify "meta" attributes (fixed kids))
 
 meta_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 meta_ = meta empty

--- a/src/Deku/DOM/Elt/Meter.purs
+++ b/src/Deku/DOM/Elt/Meter.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Meter where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Meter_
 
 meter
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Meter_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ meter attributes kids = Element' (elementify "meter" attributes (fixed kids))
 
 meter_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 meter_ = meter empty

--- a/src/Deku/DOM/Elt/Nav.purs
+++ b/src/Deku/DOM/Elt/Nav.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Nav where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Nav_
 
 nav
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Nav_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ nav attributes kids = Element' (elementify "nav" attributes (fixed kids))
 
 nav_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 nav_ = nav empty

--- a/src/Deku/DOM/Elt/Noframes.purs
+++ b/src/Deku/DOM/Elt/Noframes.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Noframes where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Noframes_
 
 noframes
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Noframes_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ noframes attributes kids = Element'
 
 noframes_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 noframes_ = noframes empty

--- a/src/Deku/DOM/Elt/Noscript.purs
+++ b/src/Deku/DOM/Elt/Noscript.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Noscript where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Noscript_
 
 noscript
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Noscript_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ noscript attributes kids = Element'
 
 noscript_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 noscript_ = noscript empty

--- a/src/Deku/DOM/Elt/Object.purs
+++ b/src/Deku/DOM/Elt/Object.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Object where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Object_
 
 object
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Object_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ object attributes kids = Element' (elementify "object" attributes (fixed kids))
 
 object_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 object_ = object empty

--- a/src/Deku/DOM/Elt/Ol.purs
+++ b/src/Deku/DOM/Elt/Ol.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Ol where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Ol_
 
 ol
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Ol_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ ol attributes kids = Element' (elementify "ol" attributes (fixed kids))
 
 ol_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 ol_ = ol empty

--- a/src/Deku/DOM/Elt/Optgroup.purs
+++ b/src/Deku/DOM/Elt/Optgroup.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Optgroup where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Optgroup_
 
 optgroup
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Optgroup_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ optgroup attributes kids = Element'
 
 optgroup_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 optgroup_ = optgroup empty

--- a/src/Deku/DOM/Elt/Option.purs
+++ b/src/Deku/DOM/Elt/Option.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Option where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Option_
 
 option
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Option_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ option attributes kids = Element' (elementify "option" attributes (fixed kids))
 
 option_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 option_ = option empty

--- a/src/Deku/DOM/Elt/Output.purs
+++ b/src/Deku/DOM/Elt/Output.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Output where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Output_
 
 output
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Output_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ output attributes kids = Element' (elementify "output" attributes (fixed kids))
 
 output_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 output_ = output empty

--- a/src/Deku/DOM/Elt/P.purs
+++ b/src/Deku/DOM/Elt/P.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.P where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data P_
 
 p
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute P_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ p attributes kids = Element' (elementify "p" attributes (fixed kids))
 
 p_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 p_ = p empty

--- a/src/Deku/DOM/Elt/Param.purs
+++ b/src/Deku/DOM/Elt/Param.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Param where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Param_
 
 param
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Param_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ param attributes kids = Element' (elementify "param" attributes (fixed kids))
 
 param_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 param_ = param empty

--- a/src/Deku/DOM/Elt/Picture.purs
+++ b/src/Deku/DOM/Elt/Picture.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Picture where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Picture_
 
 picture
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Picture_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ picture attributes kids = Element'
 
 picture_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 picture_ = picture empty

--- a/src/Deku/DOM/Elt/Pre.purs
+++ b/src/Deku/DOM/Elt/Pre.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Pre where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Pre_
 
 pre
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Pre_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ pre attributes kids = Element' (elementify "pre" attributes (fixed kids))
 
 pre_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 pre_ = pre empty

--- a/src/Deku/DOM/Elt/Progress.purs
+++ b/src/Deku/DOM/Elt/Progress.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Progress where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Progress_
 
 progress
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Progress_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ progress attributes kids = Element'
 
 progress_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 progress_ = progress empty

--- a/src/Deku/DOM/Elt/Q.purs
+++ b/src/Deku/DOM/Elt/Q.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Q where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Q_
 
 q
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Q_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ q attributes kids = Element' (elementify "q" attributes (fixed kids))
 
 q_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 q_ = q empty

--- a/src/Deku/DOM/Elt/Rp.purs
+++ b/src/Deku/DOM/Elt/Rp.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Rp where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Rp_
 
 rp
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Rp_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ rp attributes kids = Element' (elementify "rp" attributes (fixed kids))
 
 rp_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 rp_ = rp empty

--- a/src/Deku/DOM/Elt/Rt.purs
+++ b/src/Deku/DOM/Elt/Rt.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Rt where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Rt_
 
 rt
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Rt_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ rt attributes kids = Element' (elementify "rt" attributes (fixed kids))
 
 rt_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 rt_ = rt empty

--- a/src/Deku/DOM/Elt/Ruby.purs
+++ b/src/Deku/DOM/Elt/Ruby.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Ruby where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Ruby_
 
 ruby
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Ruby_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ ruby attributes kids = Element' (elementify "ruby" attributes (fixed kids))
 
 ruby_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 ruby_ = ruby empty

--- a/src/Deku/DOM/Elt/S.purs
+++ b/src/Deku/DOM/Elt/S.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.S where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data S_
 
 s
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute S_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ s attributes kids = Element' (elementify "s" attributes (fixed kids))
 
 s_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 s_ = s empty

--- a/src/Deku/DOM/Elt/Samp.purs
+++ b/src/Deku/DOM/Elt/Samp.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Samp where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Samp_
 
 samp
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Samp_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ samp attributes kids = Element' (elementify "samp" attributes (fixed kids))
 
 samp_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 samp_ = samp empty

--- a/src/Deku/DOM/Elt/Script.purs
+++ b/src/Deku/DOM/Elt/Script.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Script where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Script_
 
 script
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Script_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ script attributes kids = Element' (elementify "script" attributes (fixed kids))
 
 script_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 script_ = script empty

--- a/src/Deku/DOM/Elt/Section.purs
+++ b/src/Deku/DOM/Elt/Section.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Section where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Section_
 
 section
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Section_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ section attributes kids = Element'
 
 section_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 section_ = section empty

--- a/src/Deku/DOM/Elt/Select.purs
+++ b/src/Deku/DOM/Elt/Select.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Select where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Select_
 
 select
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Select_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ select attributes kids = Element' (elementify "select" attributes (fixed kids))
 
 select_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 select_ = select empty

--- a/src/Deku/DOM/Elt/Small.purs
+++ b/src/Deku/DOM/Elt/Small.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Small where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Small_
 
 small
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Small_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ small attributes kids = Element' (elementify "small" attributes (fixed kids))
 
 small_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 small_ = small empty

--- a/src/Deku/DOM/Elt/Source.purs
+++ b/src/Deku/DOM/Elt/Source.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Source where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Source_
 
 source
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Source_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ source attributes kids = Element' (elementify "source" attributes (fixed kids))
 
 source_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 source_ = source empty

--- a/src/Deku/DOM/Elt/Span.purs
+++ b/src/Deku/DOM/Elt/Span.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Span where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Span_
 
 span
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Span_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ span attributes kids = Element' (elementify "span" attributes (fixed kids))
 
 span_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 span_ = span empty

--- a/src/Deku/DOM/Elt/Strike.purs
+++ b/src/Deku/DOM/Elt/Strike.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Strike where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Strike_
 
 strike
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Strike_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ strike attributes kids = Element' (elementify "strike" attributes (fixed kids))
 
 strike_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 strike_ = strike empty

--- a/src/Deku/DOM/Elt/Strong.purs
+++ b/src/Deku/DOM/Elt/Strong.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Strong where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Strong_
 
 strong
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Strong_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ strong attributes kids = Element' (elementify "strong" attributes (fixed kids))
 
 strong_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 strong_ = strong empty

--- a/src/Deku/DOM/Elt/Style.purs
+++ b/src/Deku/DOM/Elt/Style.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Style where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Style_
 
 style
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Style_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ style attributes kids = Element' (elementify "style" attributes (fixed kids))
 
 style_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 style_ = style empty

--- a/src/Deku/DOM/Elt/Sub.purs
+++ b/src/Deku/DOM/Elt/Sub.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Sub where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Sub_
 
 sub
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Sub_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ sub attributes kids = Element' (elementify "sub" attributes (fixed kids))
 
 sub_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 sub_ = sub empty

--- a/src/Deku/DOM/Elt/Summary.purs
+++ b/src/Deku/DOM/Elt/Summary.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Summary where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Summary_
 
 summary
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Summary_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ summary attributes kids = Element'
 
 summary_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 summary_ = summary empty

--- a/src/Deku/DOM/Elt/Sup.purs
+++ b/src/Deku/DOM/Elt/Sup.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Sup where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Sup_
 
 sup
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Sup_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ sup attributes kids = Element' (elementify "sup" attributes (fixed kids))
 
 sup_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 sup_ = sup empty

--- a/src/Deku/DOM/Elt/Svg.purs
+++ b/src/Deku/DOM/Elt/Svg.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Svg where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Svg_
 
 svg
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Svg_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ svg attributes kids = Element' (elementify "svg" attributes (fixed kids))
 
 svg_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 svg_ = svg empty

--- a/src/Deku/DOM/Elt/Table.purs
+++ b/src/Deku/DOM/Elt/Table.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Table where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Table_
 
 table
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Table_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ table attributes kids = Element' (elementify "table" attributes (fixed kids))
 
 table_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 table_ = table empty

--- a/src/Deku/DOM/Elt/Tbody.purs
+++ b/src/Deku/DOM/Elt/Tbody.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Tbody where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Tbody_
 
 tbody
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Tbody_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ tbody attributes kids = Element' (elementify "tbody" attributes (fixed kids))
 
 tbody_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 tbody_ = tbody empty

--- a/src/Deku/DOM/Elt/Td.purs
+++ b/src/Deku/DOM/Elt/Td.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Td where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Td_
 
 td
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Td_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ td attributes kids = Element' (elementify "td" attributes (fixed kids))
 
 td_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 td_ = td empty

--- a/src/Deku/DOM/Elt/Template.purs
+++ b/src/Deku/DOM/Elt/Template.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Template where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Template_
 
 template
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Template_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ template attributes kids = Element'
 
 template_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 template_ = template empty

--- a/src/Deku/DOM/Elt/Textarea.purs
+++ b/src/Deku/DOM/Elt/Textarea.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Textarea where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Textarea_
 
 textarea
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Textarea_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -20,7 +21,7 @@ textarea attributes kids = Element'
 
 textarea_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 textarea_ = textarea empty

--- a/src/Deku/DOM/Elt/Tfoot.purs
+++ b/src/Deku/DOM/Elt/Tfoot.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Tfoot where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Tfoot_
 
 tfoot
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Tfoot_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ tfoot attributes kids = Element' (elementify "tfoot" attributes (fixed kids))
 
 tfoot_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 tfoot_ = tfoot empty

--- a/src/Deku/DOM/Elt/Th.purs
+++ b/src/Deku/DOM/Elt/Th.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Th where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Th_
 
 th
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Th_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ th attributes kids = Element' (elementify "th" attributes (fixed kids))
 
 th_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 th_ = th empty

--- a/src/Deku/DOM/Elt/Thead.purs
+++ b/src/Deku/DOM/Elt/Thead.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Thead where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Thead_
 
 thead
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Thead_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ thead attributes kids = Element' (elementify "thead" attributes (fixed kids))
 
 thead_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 thead_ = thead empty

--- a/src/Deku/DOM/Elt/Time.purs
+++ b/src/Deku/DOM/Elt/Time.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Time where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Time_
 
 time
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Time_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ time attributes kids = Element' (elementify "time" attributes (fixed kids))
 
 time_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 time_ = time empty

--- a/src/Deku/DOM/Elt/Title.purs
+++ b/src/Deku/DOM/Elt/Title.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Title where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Title_
 
 title
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Title_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ title attributes kids = Element' (elementify "title" attributes (fixed kids))
 
 title_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 title_ = title empty

--- a/src/Deku/DOM/Elt/Tr.purs
+++ b/src/Deku/DOM/Elt/Tr.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Tr where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Tr_
 
 tr
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Tr_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ tr attributes kids = Element' (elementify "tr" attributes (fixed kids))
 
 tr_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 tr_ = tr empty

--- a/src/Deku/DOM/Elt/Track.purs
+++ b/src/Deku/DOM/Elt/Track.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Track where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Track_
 
 track
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Track_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ track attributes kids = Element' (elementify "track" attributes (fixed kids))
 
 track_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 track_ = track empty

--- a/src/Deku/DOM/Elt/Tt.purs
+++ b/src/Deku/DOM/Elt/Tt.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Tt where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Tt_
 
 tt
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Tt_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ tt attributes kids = Element' (elementify "tt" attributes (fixed kids))
 
 tt_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 tt_ = tt empty

--- a/src/Deku/DOM/Elt/U.purs
+++ b/src/Deku/DOM/Elt/U.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.U where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data U_
 
 u
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute U_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ u attributes kids = Element' (elementify "u" attributes (fixed kids))
 
 u_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 u_ = u empty

--- a/src/Deku/DOM/Elt/Ul.purs
+++ b/src/Deku/DOM/Elt/Ul.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Ul where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Ul_
 
 ul
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Ul_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ ul attributes kids = Element' (elementify "ul" attributes (fixed kids))
 
 ul_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 ul_ = ul empty

--- a/src/Deku/DOM/Elt/Var.purs
+++ b/src/Deku/DOM/Elt/Var.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Var where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Var_
 
 var
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Var_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ var attributes kids = Element' (elementify "var" attributes (fixed kids))
 
 var_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 var_ = var empty

--- a/src/Deku/DOM/Elt/Video.purs
+++ b/src/Deku/DOM/Elt/Video.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Video where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Video_
 
 video
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Video_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ video attributes kids = Element' (elementify "video" attributes (fixed kids))
 
 video_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 video_ = video empty

--- a/src/Deku/DOM/Elt/Wbr.purs
+++ b/src/Deku/DOM/Elt/Wbr.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Wbr where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Wbr_
 
 wbr
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Wbr_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ wbr attributes kids = Element' (elementify "wbr" attributes (fixed kids))
 
 wbr_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 wbr_ = wbr empty

--- a/src/Deku/DOM/Elt/Xdata.purs
+++ b/src/Deku/DOM/Elt/Xdata.purs
@@ -1,9 +1,10 @@
 module Deku.DOM.Elt.Xdata where
 
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Deku.Attribute (Attribute)
 import Deku.Control (elementify)
-import Deku.Core (Domable, class Korok)
+import Deku.Core (Domable)
 import Bolson.Core (Entity(..), fixed)
 import FRP.Event (AnEvent)
 
@@ -11,7 +12,7 @@ data Xdata_
 
 xdata
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => AnEvent m (Attribute Xdata_)
   -> Array (Domable m lock payload)
   -> Domable m lock payload
@@ -19,7 +20,7 @@ xdata attributes kids = Element' (elementify "data" attributes (fixed kids))
 
 xdata_
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => Array (Domable m lock payload)
   -> Domable m lock payload
 xdata_ = xdata empty

--- a/src/Deku/Interpret.purs
+++ b/src/Deku/Interpret.purs
@@ -199,26 +199,26 @@ mermaidDOMInterpret seed = Core.DOMInterpret
       void $ RRef.modify (add 1) seed
       pure o
   , makeElement: \a (b /\ c) -> do
-      liftPure $ ssrMakeElement a b
       liftImpure $ makeElement_ true a c
+      liftPure $ ssrMakeElement a b
   , attributeParent: \a (_ /\ c) -> do
       liftImpure $ attributeParent_ a c
   , makeRoot: \a (_ /\ c) -> do
       liftImpure $ makeRoot_ a c
   , makeText: \a (b /\ c) -> do
-      liftPure $ ssrMakeText a b
       liftImpure $ makeText_ true (maybe unit) a c
+      liftPure $ ssrMakeText a b
   , makePursx: \a (b /\ c) -> do
-      liftPure $ ssrMakePursx a b
       liftImpure $ makePursx_ true (maybe unit) a c
+      liftPure $ ssrMakePursx a b
   , setProp: \a (b /\ c) -> do
-      liftPure $ ssrSetProp a b
       liftImpure $ setProp_ true a c
+      liftPure $ ssrSetProp a b
   , setCb: \a (_ /\ c) -> do
       liftImpure $ setCb_ true a c
   , setText: \a (b /\ c) -> do
-      liftPure $ ssrSetText a b
       liftImpure $ setText_ a c
+      liftPure $ ssrSetText a b
   , sendToPos: \a (_ /\ c) -> do
       liftImpure $ sendToPos_ a c
   , deleteFromCache: \a (_ /\ c) -> do

--- a/src/Deku/Interpret.purs
+++ b/src/Deku/Interpret.purs
@@ -13,7 +13,6 @@ import Prelude
 import Control.Monad.ST (ST)
 import Control.Monad.ST.Internal as RRef
 import Data.Maybe (Maybe, maybe)
-import Data.Tuple.Nested (type (/\), (/\))
 import Deku.Core as Core
 import Effect (Effect)
 import Effect.Ref as Ref
@@ -136,7 +135,7 @@ mermaidDOMInterpret
   :: forall r
    . RRef.STRef r Int
   -> Core.DOMInterpret (Mermaid r)
-       (RRef.STRef r (Array Instruction) /\ FFIDOMSnapshot -> Mermaid r Unit)
+       (RRef.STRef r (Array Instruction) -> FFIDOMSnapshot -> Mermaid r Unit)
 mermaidDOMInterpret seed = Core.DOMInterpret
   { ids: liftPure do
       seed' <- RRef.read seed
@@ -145,33 +144,33 @@ mermaidDOMInterpret seed = Core.DOMInterpret
           { newSeed: mkSeed seed', size: 5 }
       void $ RRef.modify (add 1) seed
       pure o
-  , makeElement: \a (b /\ c) -> do
+  , makeElement: \a b c -> do
       liftImpure $ makeElement_ true a c
       liftPure $ ssrMakeElement a b
-  , attributeParent: \a (_ /\ c) -> do
+  , attributeParent: \a _ c -> do
       liftImpure $ attributeParent_ a c
-  , makeRoot: \a (_ /\ c) -> do
+  , makeRoot: \a _ c -> do
       liftImpure $ makeRoot_ a c
-  , makeText: \a (b /\ c) -> do
+  , makeText: \a b c -> do
       liftImpure $ makeText_ true (maybe unit) a c
       liftPure $ ssrMakeText a b
-  , makePursx: \a (b /\ c) -> do
+  , makePursx: \a b c -> do
       liftImpure $ makePursx_ true (maybe unit) a c
       liftPure $ ssrMakePursx a b
-  , setProp: \a (b /\ c) -> do
+  , setProp: \a b c -> do
       liftImpure $ setProp_ true a c
       liftPure $ ssrSetProp a b
-  , setCb: \a (_ /\ c) -> do
+  , setCb: \a _ c -> do
       liftImpure $ setCb_ true a c
-  , setText: \a (b /\ c) -> do
+  , setText: \a b c -> do
       liftImpure $ setText_ a c
       liftPure $ ssrSetText a b
-  , sendToPos: \a (_ /\ c) -> do
+  , sendToPos: \a _ c -> do
       liftImpure $ sendToPos_ a c
-  , deleteFromCache: \a (_ /\ c) -> do
+  , deleteFromCache: \a _ c -> do
       liftImpure $ deleteFromCache_ a c
-  , giveNewParent: \a (_ /\ c) -> do
+  , giveNewParent: \a _ c -> do
       liftImpure $ giveNewParent_ a c
-  , disconnectElement: \a (_ /\ c) -> do
+  , disconnectElement: \a _ c -> do
       liftImpure $ disconnectElement_ a c
   }

--- a/src/Deku/Pursx.purs
+++ b/src/Deku/Pursx.purs
@@ -5,6 +5,7 @@ import Prelude
 import Bolson.Control as Bolson
 import Bolson.Core (Element(..), Entity(..), PSR)
 import Control.Alt ((<|>))
+import Control.Monad.ST.Class (class MonadST)
 import Control.Plus (empty)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (unwrap)
@@ -12,7 +13,7 @@ import Data.Profunctor (lcmap)
 import Data.Reflectable (class Reflectable, reflectType)
 import Data.Symbol (class IsSymbol)
 import Deku.Attribute (Attribute, AttributeValue(..), unsafeUnAttribute)
-import Deku.Core (DOMInterpret(..), class Korok, Domable, Node(..))
+import Deku.Core (DOMInterpret(..), Domable, Node(..))
 import Deku.DOM (class TagToDeku)
 import FRP.Event (AnEvent, bang, subscribe, makeEvent)
 import Foreign.Object as Object
@@ -4425,7 +4426,7 @@ instance pursxToElementConsInsert ::
   , PursxToElement m lock payload rest r
   , Reflectable key String
   , IsSymbol key
-  , Korok s m
+  , MonadST s m
   ) =>
   PursxToElement m
     lock
@@ -4456,7 +4457,7 @@ else instance pursxToElementConsAttr ::
   , PursxToElement m lock payload rest r
   , Reflectable key String
   , IsSymbol key
-  , Korok s m
+  , MonadST s m
   ) =>
   PursxToElement m
     lock
@@ -4499,7 +4500,7 @@ psx
   :: forall s m lock payload (html :: Symbol)
    . Reflectable html String
   => PXStart m lock payload "~" " " html ()
-  => Korok s m
+  => MonadST s m
   => PursxToElement m lock payload RL.Nil ()
   => Proxy html
   -> Domable m lock payload
@@ -4511,7 +4512,7 @@ makePursx
   => PXStart m lock payload "~" " " html r
   => RL.RowToList r rl
   => PursxToElement m lock payload rl r
-  => Korok s m
+  => MonadST s m
   => Proxy html
   -> { | r }
   -> Domable m lock payload
@@ -4523,7 +4524,7 @@ makePursx'
   => Reflectable verb String
   => PXStart m lock payload verb " " html r
   => RL.RowToList r rl
-  => Korok s m
+  => MonadST s m
   => PursxToElement m lock payload rl r
   => Proxy verb
   -> Proxy html
@@ -4561,7 +4562,7 @@ makePursx' verb html r = Element' $ Node go
 
 __internalDekuFlatten
   :: forall s m lock payload
-   . Korok s m
+   . MonadST s m
   => PSR m
   -> DOMInterpret m payload
   -> Domable m lock payload

--- a/src/Deku/SSR.purs
+++ b/src/Deku/SSR.purs
@@ -82,7 +82,9 @@ ssr' topTag arr = "<" <> topTag <> " data-deku-ssr-deku-root=\"true\">"
     foldlWithIndex
       ( \i b a -> case hasMake a of
           true -> b
-          false -> String.replace (String.Pattern ("data-deku-ssr-" <> i)) (String.Replacement (eltAtts a <> " data-deku-ssr-" <> i)) b
+          false -> String.replace (String.Pattern ("data-deku-ssr-" <> i))
+            (String.Replacement (eltAtts a <> " data-deku-ssr-" <> i))
+            b
       )
       (o id)
       idToActions
@@ -91,7 +93,8 @@ ssr' topTag arr = "<" <> topTag <> " data-deku-ssr-deku-root=\"true\">"
       let
         makeText _ = i2a #
           ( fromMaybe "" <<< findMap case _ of
-              SetText { text } -> Just $ (encodedString text <> "<!--"<>id<>"-->")
+              SetText { text } -> Just $
+                (encodedString text <> "<!--" <> id <> "-->")
               _ -> Nothing
           )
         makeElt _ = do

--- a/src/Deku/Toplevel.purs
+++ b/src/Deku/Toplevel.purs
@@ -13,7 +13,7 @@ import Data.Newtype (class Newtype, unwrap)
 import Data.Tuple.Nested (type (/\), (/\))
 import Deku.Control (deku, deku1, dekuA)
 import Deku.Core (DOMInterpret(..), Domable, Node(..))
-import Deku.Interpret (FFIDOMSnapshot, Instruction, fullDOMInterpret, hydratingDOMInterpret, makeFFIDOMSnapshot, mermaidDOMInterpret, setHydrating, unSetHydrating)
+import Deku.Interpret (FFIDOMSnapshot, Instruction, fullDOMInterpret, makeFFIDOMSnapshot, mermaidDOMInterpret, setHydrating, unSetHydrating)
 import Deku.SSR (ssr')
 import Effect (Effect)
 import Effect.Ref as Ref

--- a/src/Deku/Toplevel.purs
+++ b/src/Deku/Toplevel.purs
@@ -94,7 +94,8 @@ runInBodyA a = void (runInBodyA' a)
 hydrate'
   :: ( forall lock
         . Domable (Mermaid Global) lock
-            ( (RRef.STRef Global (Array Instruction)) -> FFIDOMSnapshot
+            ( (RRef.STRef Global (Array Instruction))
+              -> FFIDOMSnapshot
               -> Mermaid Global Unit
             )
      )
@@ -120,7 +121,8 @@ hydrate' children = do
 hydrate
   :: ( forall lock
         . Domable (Mermaid Global) lock
-            ( (RRef.STRef Global (Array Instruction)) -> FFIDOMSnapshot
+            ( (RRef.STRef Global (Array Instruction))
+              -> FFIDOMSnapshot
               -> Mermaid Global Unit
             )
      )
@@ -136,7 +138,8 @@ runSSR
   :: Template
   -> ( forall lock
         . Domable (Mermaid Global) lock
-            ( (RRef.STRef Global (Array Instruction)) -> FFIDOMSnapshot
+            ( (RRef.STRef Global (Array Instruction))
+              -> FFIDOMSnapshot
               -> Mermaid Global Unit
             )
      )
@@ -148,7 +151,8 @@ runSSR'
   -> Template
   -> ( forall lock
         . Domable (Mermaid Global) lock
-            ( (RRef.STRef Global (Array Instruction)) -> FFIDOMSnapshot
+            ( (RRef.STRef Global (Array Instruction))
+              -> FFIDOMSnapshot
               -> Mermaid Global Unit
             )
      )

--- a/src/Deku/Toplevel.purs
+++ b/src/Deku/Toplevel.purs
@@ -10,7 +10,6 @@ import Control.Monad.ST.Global (Global, toEffect)
 import Control.Monad.ST.Internal as RRef
 import Data.Maybe (Maybe(..), maybe)
 import Data.Newtype (class Newtype, unwrap)
-import Data.Tuple.Nested (type (/\), (/\))
 import Deku.Control (deku, deku1, dekuA)
 import Deku.Core (DOMInterpret(..), Domable, Node(..))
 import Deku.Interpret (FFIDOMSnapshot, Instruction, fullDOMInterpret, makeFFIDOMSnapshot, mermaidDOMInterpret, setHydrating, unSetHydrating)
@@ -95,7 +94,7 @@ runInBodyA a = void (runInBodyA' a)
 hydrate'
   :: ( forall lock
         . Domable (Mermaid Global) lock
-            ( (RRef.STRef Global (Array Instruction)) /\ FFIDOMSnapshot
+            ( (RRef.STRef Global (Array Instruction)) -> FFIDOMSnapshot
               -> Mermaid Global Unit
             )
      )
@@ -114,14 +113,14 @@ hydrate' children = do
         di
         children
     )
-    (\k -> runImpure $ k (ins /\ ffi))
+    (\k -> runImpure $ k ins ffi)
   unSetHydrating ffi
   pure u
 
 hydrate
   :: ( forall lock
         . Domable (Mermaid Global) lock
-            ( (RRef.STRef Global (Array Instruction)) /\ FFIDOMSnapshot
+            ( (RRef.STRef Global (Array Instruction)) -> FFIDOMSnapshot
               -> Mermaid Global Unit
             )
      )
@@ -137,7 +136,7 @@ runSSR
   :: Template
   -> ( forall lock
         . Domable (Mermaid Global) lock
-            ( (RRef.STRef Global (Array Instruction)) /\ FFIDOMSnapshot
+            ( (RRef.STRef Global (Array Instruction)) -> FFIDOMSnapshot
               -> Mermaid Global Unit
             )
      )
@@ -149,7 +148,7 @@ runSSR'
   -> Template
   -> ( forall lock
         . Domable (Mermaid Global) lock
-            ( (RRef.STRef Global (Array Instruction)) /\ FFIDOMSnapshot
+            ( (RRef.STRef Global (Array Instruction)) -> FFIDOMSnapshot
               -> Mermaid Global Unit
             )
      )
@@ -170,7 +169,7 @@ runSSR' topTag (Template { head, tail }) children =
           dint
           children
       )
-      (\k -> runPure $ k (inst /\ ffi))
+      (\k -> runPure $ k inst ffi)
     RRef.read inst
 
 __internalDekuFlatten


### PR DESCRIPTION
## Summary

* Instead of turning `Domable Effect` into `Domable m` for SSR and Hydration, this intends to make `Mermaid` the "core" monad for said use-case.
* This effectively inverts the polymorphism in that instead of having polymorphic `m` in `Domable`, we'll have polymorphic `runX` functions to account for `Effect`, `Mermaid`, and `ST`.

## TODO
- [ ] Export `bus`/`bussed` from `FRP.Event` and `Bolson.Core` instead of redefining with `always`
- [ ] `mermaid` breaks `vbus` as its runtime representation is not isomorphic to that of `ST`/`Effect`
- [ ] Provide a way to run `Domable Mermaid` in an `Effect`. Right now, it can only be used in the context of SSR and Hydration