### PR TITLE
Fix switcher behaviour for multiple pure values.

### DIFF
--- a/deku/test/Test/Main.purs
+++ b/deku/test/Test/Main.purs
@@ -22,7 +22,7 @@ import Deku.DOM.Attributes as DA
 import Deku.DOM.Combinators (injectElementT)
 import Deku.DOM.Listeners as DL
 import Deku.Do as Deku
-import Deku.Hooks (dynOptions, guard, guardWith, useDyn, useDynWith, useDynAtBeginning, useDynAtEnd, useDynAtEndWith, useHot, useHotRant, useRant, useRef, useState, useState', (<#~>))
+import Deku.Hooks (dynOptions, guard, guardWith, useDyn, useDynAtBeginning, useDynAtEnd, useDynAtEndWith, useDynWith, useHot, useHotRant, useRant, useRef, useState, useState', (<#~>))
 import Deku.Hooks as DH
 import Deku.Interpret (FFIDOMSnapshot)
 import Deku.Pursx ((~~))
@@ -650,6 +650,16 @@ lotsOfSwitching = Deku.do
         [ item <#~> if _ then text_ "hello" else text_ "goodbye"
         ]
     ]
+
+pureSwitches :: Nut
+pureSwitches = Deku.do
+  _ /\ elem <- useState'
+  let
+    initial :: Poll Unit
+    initial = merge $ Array.replicate 5 $ pure unit
+
+  ( initial <|> elem ) <#~> \e ->
+    D.span [ DA.klass_ "switcherelem" ] [ text_ $ show e ]
 
 useHotRantWorks :: Nut
 useHotRantWorks = Deku.do

--- a/index.test.js
+++ b/index.test.js
@@ -346,6 +346,14 @@ describe("deku", () => {
     })
   );
 
+  doTest( "pure switches", (f) =>
+    f( tests.pureSwitches, () =>
+    {
+      const $ = require("jquery");
+      expect( $(".switcherelem").length).toBe(1)
+    })
+  );
+
   doTest("attributes are correctly unset", (f) =>
     f(tests.unsetUnsets, () => {
       const $ = require("jquery");


### PR DESCRIPTION
When switcher receives a `Poll` with multiple pure values all will be rendered at the same time and none will get their remove event triggered. 

I've added a `useMemoized` hook that should fix the issues introduced by `useRant` and `useReflect` but I'm not sure if this implementation is save to export.