### PR TITLE
Add `package` section to `spago.yaml` so `deku` can be added through `extraPackages`

### DIFF
--- a/spago.yaml
+++ b/spago.yaml
@@ -1,3 +1,11 @@
+package:
+  name: deku
+  dependencies:
+    - tldr
+    - hyrule
+    - tidy
+    - dodo-printer
+    - tidy-codegen
 workspace:
   packageSet:
     registry: 58.0.0


### PR DESCRIPTION
The current version of [deku in the PureScript Registry 64.10.0](https://github.com/purescript/registry/blob/main/metadata/deku.json) is 0.9.24. I'd like to use the current version of `deku`.

When adding this GitHub repo in the extraPackages section to `spago.yaml` as follows:
```
workspace:
  packageSet:
    registry: 64.10.0
  extraPackages:
    deku:
      git: https://github.com/mikesol/purescript-deku.git
      ref: v0.12.1
``` 
spago version 0.93.44 gives the error message:
```
❯ spago install deku
Reading Spago workspace configuration...

✓ Selecting package to build: deku-hello-world

Cloning https://github.com/mikesol/purescript-deku.git

✘ Read the configuration at path "/Users/shaun/workspace/deku-hello-world/.spago/p/deku/v0.12.1"
However, it didn't contain a `package` section.
```
This PR adds a `package` section to the `spago.yaml` in deku, which seems to resolve the problem and allows `spago install deku` to succeed.